### PR TITLE
PacketProcessor: Fix NPE spam in disconnect

### DIFF
--- a/Impl/src/main/java/dev/brighten/anticheat/processing/PacketProcessor.java
+++ b/Impl/src/main/java/dev/brighten/anticheat/processing/PacketProcessor.java
@@ -61,6 +61,7 @@ public class PacketProcessor {
                 if(KauriAPI.INSTANCE.getPacketExemptedPlayers().contains(data.uuid)) return;
 
                 ThreadHandler.INSTANCE.getThread(data).runTask(() -> {
+                    if (data.checkManager == null) return;
                     try {
                         if(outgoingPackets.contains(info.getType())) {
                             processServer(data, info.getPacket(), info.getType(), info.getTimestamp());


### PR DESCRIPTION
We might want to also remove from PlayerThread but i am not too sure as this probably can also happen with fast reconnect.